### PR TITLE
fix: package the custom menu-bar icon on start

### DIFF
--- a/BrightspaceBar/Makefile
+++ b/BrightspaceBar/Makefile
@@ -2,6 +2,7 @@
 #
 #   make test              hermetic suite (no network, no daemon) — the default
 #   make live              adds the live-tenant tests, which spawn the real daemon
+#   make bundle            build, bundle, sign
 #   make run               build, bundle, sign, launch into the menu bar
 #   make smoke             launch + verify the process survives 3s, then kill
 #   make build / clean
@@ -12,7 +13,7 @@
 # Each module also has its own Makefile: `make -C Modules/CoursePipeline test`
 # runs just that module's suite.
 
-.PHONY: build test live run smoke clean
+.PHONY: build test live bundle run smoke clean
 
 # A CommandLineTools-only toolchain (no Xcode) ships Testing.framework but
 # doesn't tell swiftpm where it lives, so plain `swift test` dies with
@@ -26,6 +27,9 @@ test:
 
 build:
 	swift build
+
+bundle:
+	./Scripts/run.sh --bundle
 
 # BS_LIVE gates the cases that reach the tenant. They spawn the real daemon
 # with --no-full-login (a suite must never push MFA to a phone), so they need

--- a/BrightspaceBar/Modules/BrightspaceBar/Tests/MfaIconWiringTests.swift
+++ b/BrightspaceBar/Modules/BrightspaceBar/Tests/MfaIconWiringTests.swift
@@ -104,6 +104,13 @@ struct MfaIconWiringTests {
         try self.source("Modules/BrightspaceBar/Sources/main.swift")
     }
 
+    private func repositorySource(_ path: String) throws -> String {
+        try String(
+            contentsOf: Self.packageRoot.deletingLastPathComponent().appending(path: path),
+            encoding: .utf8
+        )
+    }
+
     @Test("the scan finds both files")
     func theScanIsNotVacuous() throws {
         // Arrange / Act — a read that returned an empty string would pass every
@@ -209,5 +216,20 @@ struct MfaIconWiringTests {
             text.contains("show(code:"),
             "main.swift must hand the watcher's reports to StatusBarController.show(code:)"
         )
+    }
+
+    @Test("the normal start path packages the custom menu-bar icon")
+    func theNormalStartPathUsesTheAppBundle() throws {
+        let makefile = try self.repositorySource("Makefile")
+        let launcher = try self.repositorySource("session-capture/src/start.mjs")
+        let bundler = try self.source("Scripts/run.sh")
+        let controller = try self.controllerSource()
+
+        #expect(makefile.contains("start:\n\t$(MAKE) -C BrightspaceBar bundle"))
+        #expect(launcher.contains("BrightspaceBar.app"))
+        #expect(launcher.contains("Contents\", \"MacOS\", \"BrightspaceBar"))
+        #expect(bundler.contains("Modules/${APP_NAME}/Resources/MotionP.pdf"))
+        #expect(bundler.contains("${APP}/Contents/Resources/MotionP.pdf"))
+        #expect(controller.contains("Bundle.main.url(forResource: \"MotionP\", withExtension: \"pdf\")"))
     }
 }

--- a/BrightspaceBar/Scripts/run.sh
+++ b/BrightspaceBar/Scripts/run.sh
@@ -7,8 +7,9 @@
 # lines because it also handles Sparkle, notarization, provisioning profiles, and
 # keychain groups — none of which a local menu-bar experiment needs.
 #
-# Usage:  ./Scripts/run.sh          build, bundle, launch
-#         ./Scripts/run.sh --smoke  build, bundle, launch, verify alive, then kill
+# Usage:  ./Scripts/run.sh           build, bundle, launch
+#         ./Scripts/run.sh --bundle  build, bundle, sign
+#         ./Scripts/run.sh --smoke   build, bundle, launch, verify alive, then kill
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
@@ -18,12 +19,23 @@ APP="${ROOT_DIR}/.build/${CONFIG}/${APP_NAME}.app"
 EXE="${ROOT_DIR}/.build/${CONFIG}/${APP_NAME}"
 PROCESS_PATTERN="${APP_NAME}.app/Contents/MacOS/${APP_NAME}"
 SMOKE=0
-[ "${1:-}" = "--smoke" ] && SMOKE=1
+BUNDLE_ONLY=0
+case "${1:-}" in
+  "") ;;
+  --bundle) BUNDLE_ONLY=1 ;;
+  --smoke) SMOKE=1 ;;
+  *)
+    echo "Usage: $0 [--bundle|--smoke]" >&2
+    exit 64
+    ;;
+esac
 
 log() { printf '==> %s\n' "$*"; }
 
-log "Stopping any running instance"
-pkill -f "${PROCESS_PATTERN}" 2>/dev/null || true
+if [ "${BUNDLE_ONLY}" -eq 0 ]; then
+    log "Stopping any running instance"
+    pkill -f "${PROCESS_PATTERN}" 2>/dev/null || true
+fi
 
 log "swift build (${CONFIG})"
 swift build -c "${CONFIG}" --package-path "${ROOT_DIR}"
@@ -46,6 +58,11 @@ cp -f "${ROOT_DIR}/Modules/${APP_NAME}/Resources/MotionP.pdf" \
 # Developer ID and notarization, which is out of scope for this experiment.
 log "Signing (ad-hoc)"
 codesign --force --sign - "${APP}" >/dev/null 2>&1
+
+if [ "${BUNDLE_ONLY}" -eq 1 ]; then
+    log "Bundled at ${APP}"
+    exit 0
+fi
 
 log "Launching"
 open -n "${APP}"

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ skill:
 	@echo "Agents that read those directories now see the 'brightspace-bar' skill (restart a running session to load it)."
 
 start:
-	$(MAKE) -C BrightspaceBar build
+	$(MAKE) -C BrightspaceBar bundle
 	cd session-capture && npm run start
 
 setup:

--- a/session-capture/scripts/E2E.md
+++ b/session-capture/scripts/E2E.md
@@ -68,7 +68,7 @@ the shell environment, so a non-default root needs the binary or an explicit
 
 ```sh
 cd ~/PaperShelf/BrightspaceBar && ./Scripts/run.sh          # production root
-BSB_ROOT="$ROOT" .build/debug/BrightspaceBar                # rehearsal root
+BSB_ROOT="$ROOT" .build/debug/BrightspaceBar.app/Contents/MacOS/BrightspaceBar
 open -n --env BSB_ROOT="$ROOT" .build/debug/BrightspaceBar.app
 ```
 

--- a/session-capture/scripts/e2e.sh
+++ b/session-capture/scripts/e2e.sh
@@ -317,7 +317,7 @@ print_app_step() {
   against a non-default root, run.sh's launch will read the PRODUCTION root.
   For a rehearsal root, launch one of these instead:
 
-    BSB_ROOT="$ROOT" $SWIFT_DIR/.build/debug/BrightspaceBar
+    BSB_ROOT="$ROOT" $SWIFT_DIR/.build/debug/BrightspaceBar.app/Contents/MacOS/BrightspaceBar
     open -n --env BSB_ROOT="$ROOT" $SWIFT_DIR/.build/debug/BrightspaceBar.app
 
   BRIGHTSPACEBAR_STUB must NOT be set, or the menu shows fabricated courses.

--- a/session-capture/src/start.mjs
+++ b/session-capture/src/start.mjs
@@ -22,7 +22,8 @@ import { loadCredentials, promptForCredentials } from "./credentials.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.join(__dirname, "..", "..");
-const APP_BINARY = path.join(REPO_ROOT, "BrightspaceBar", ".build", "debug", "BrightspaceBar");
+const APP = path.join(REPO_ROOT, "BrightspaceBar", ".build", "debug", "BrightspaceBar.app");
+const APP_BINARY = path.join(APP, "Contents", "MacOS", "BrightspaceBar");
 
 // 1. Credentials: load, or prompt when a human is on the other end.
 let credentials = loadCredentials();
@@ -48,10 +49,10 @@ const running = spawnSync("pgrep", ["-f", APP_BINARY]).status === 0;
 if (running) {
   console.error("BrightspaceBar is already running — not launching a second copy.");
 } else if (!existsSync(APP_BINARY)) {
-  console.error(`app binary not found at ${APP_BINARY} — run \`make start\` (it builds first)`);
+  console.error(`app bundle not found at ${APP}: run \`make start\` (it builds it first)`);
   process.exit(1);
 } else {
-  const app = spawn(APP_BINARY, [], { detached: true, stdio: "ignore" });
+  const app = spawn("open", ["-n", APP], { detached: true, stdio: "ignore" });
   app.unref();
   console.error("launched BrightspaceBar into the menu bar");
 }

--- a/session-capture/src/start.mjs
+++ b/session-capture/src/start.mjs
@@ -52,7 +52,13 @@ if (running) {
   console.error(`app bundle not found at ${APP}: run \`make start\` (it builds it first)`);
   process.exit(1);
 } else {
-  const app = spawn("open", ["-n", APP], { detached: true, stdio: "ignore" });
+  // The executable INSIDE the bundle, spawned directly — not `open -n`.
+  // LaunchServices does not pass the caller's environment through, so a
+  // BSB_ROOT set for `make start` would be dropped and the app would read
+  // the production root. Spawning the binary keeps the environment, and
+  // Bundle.main still resolves to the .app because that is where the
+  // executable lives, so MotionP.pdf loads either way.
+  const app = spawn(APP_BINARY, [], { detached: true, stdio: "ignore" });
   app.unref();
   console.error("launched BrightspaceBar into the menu bar");
 }


### PR DESCRIPTION
## Summary

- bundle the app before the standard start flow runs the daemon
- launch and detect the executable inside BrightspaceBar.app
- add a regression test for the package, launch, and resource contract
- update E2E instructions to use the bundled executable

Fixes #4

## Verification

- make -C BrightspaceBar test
- cd session-capture && npm test
- make -C BrightspaceBar bundle, then verified MotionP.pdf and the ad-hoc signature